### PR TITLE
Fix breakpoint

### DIFF
--- a/app.css
+++ b/app.css
@@ -19,3 +19,11 @@
 .eager-forecast iframe {
   border: none;
 }
+
+@media(max-width: 500px) {
+  /* Force the breakpoint earlier, so the forecast doesn't fall outside the viewport. */
+  .eager-forecast {
+    max-width: 390px;
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
@ConzorKingKong This is in response to a support ticket.  The user noticed that the forecast can become clipped on mobile devices where the width is between around 400 and 500 pixels.  It looks like the Forecast widget does have a breakpoint to change its layout on narrow screens, but it's triggered a at around 400 pixels, when it needs to happen around 500.  This change fixes that by resizing the containing element when the screen gets narrow.

You can view a preview of this branch here: https://eager.io/developer/app-tester?version=298itykdneo-1454432766785

Please merge and [create a release](https://github.com/ConzorKingKong/EagerForecastIO/releases) which I will import into the app :).
